### PR TITLE
fix: Fix bug where kubernetes labels are omitted and never arrived at prometheus

### DIFF
--- a/prometheus-grafana-values.yaml
+++ b/prometheus-grafana-values.yaml
@@ -16,3 +16,11 @@ prometheus:
         scrape_interval: 5s
         static_configs:
           - targets: ['ebpf-exporter-service.ebpf.svc.cluster.local:9435']
+
+kube-state-metrics:
+  metricLabelsAllowlist:
+    - namespaces=[*]
+    - pods=[*]
+  metricAnnotationsAllowList:
+    - pods=[*]
+    - namespaces=[*]


### PR DESCRIPTION
closes #30

I had to allow all labels. Later on we could go and make this less open, as they warn that allowing more labels have an severe performance impact.