### PR TITLE
fix: persistent disks sizes for created pods are now smaller

### DIFF
--- a/airflow-values.yaml
+++ b/airflow-values.yaml
@@ -13,6 +13,8 @@ webserver:
 
 workers:
   replicas: 3
+  persistence:
+    size: 20Gi
 
 env:
   - name: "AIRFLOW__CORE__LOAD_EXAMPLES"


### PR DESCRIPTION
decreased the volume size from 100GB to 20GB per airflow pod